### PR TITLE
Create product_toolbox.md

### DIFF
--- a/docs/product_toolbox.md
+++ b/docs/product_toolbox.md
@@ -1,23 +1,18 @@
 ---
 title: Værktøjskasse til projekter og produkter
 layout: default
-nav_order: 4
 has_children: true
-has_toc: true
+has_toc: false
+nav_order: 12
 ---
 
-# Værktøjskasse til projekter og produkter
-Type: Overblik  
-{: .label }
+# Værktøjskasse til projekter og produkter <span class="label label-purple">Overblik</span> <span class="label">Sekretariat · Projekter &amp; produkter</span>
 
-Til: Sekretariat · Projekter & produkter  
-{: .label }
+*🔎 Overblik:* Ét sted med **Trin for trin**, **Værktøjer** og **Skabeloner** til det daglige arbejde i OS2-fællesskabet.  
+*🛠️ Skal du løse en opgave nu?* Brug menupunkterne herunder – eller søg i venstremenuen (kommer snart!)
 
 Velkommen til OS2’s praktiske værktøjskasse – stedet hvor du hurtigt finder **how-to**, **værktøjer** og **skabeloner** til drift og samarbejde i projekter og produkter.
 
-## Find hurtigt
-- 📂 **Fildeling (Nextcloud)** – [overblik & genveje](#fildeling-nextcloud)
-- 🗂️ **Skabeloner** – [agenda, referat, roadmap, release notes](#skabeloner)
-
 
 > 🙌 **Bidrag gerne:** Mangler der noget, så opret et issue eller foreslå en ændring.
+{: .note }


### PR DESCRIPTION
## Hvad
Landingsside for værktøjskassen (TOC + ankre nu; undersider kommer løbende).

Labels til tydelighed: Type (Overblik/Trin for trin/Værktøj/Skabelon) og Til (Sekretariat/Projekter & produkter/Begge).

## Hvorfor

Gør håndbogen brugbar for alle, uden at flytte eksisterende indhold. Hjælper til at navigere mellem sider, der giver overblik (når jeg skal forstå noget) og sider, der hjælper mig med handling (når jeg skal gøre noget). 

Klar adskillelse: Overblik = _forstå_ (rammesider). Trin for trin/Værktøj/Skabelon = _gøre_ (ligger i værktøjskassen).

## Hvordan

Kun ny indgang + mikro-copy på landingssiden.

Ingen breaking changes; næste PR tilføjer “Fildeling (Nextcloud)” som Værktøj med tilhørende Trin-for-trin.

Bemærk

GitHub-preview viser labels som rå tekst; de renderer korrekt på det byggede site (Just-the-Docs).

## Næste skridt

PR2: korte ramme-introer på “Arbejdsformer” og “Processer”.

PR3: Fildeling (Nextcloud) + Trin-for-trin + Skabelon.