### PR TITLE
[Docs] “Processer og rutiner”: ramme-intro + labels + link til Værktøjskassen

### DIFF
--- a/docs/processes_and_rutines.md
+++ b/docs/processes_and_rutines.md
@@ -6,7 +6,12 @@ has_children: true
 has_toc: false
 ---
 
-# Processer og rutiner  
+# Processer og rutiner <span class="label label-purple">Overblik</span> <span class="label">Sekretariat · Projekter &amp; produkter</span>
+
+*🔎 Overblik:* Rammer for forløb, roller og beslutningspunkter på tværs af OS2.  
+*🛠️ Skal du løse en opgave nu?* Gå til **[Værktøjskassen](./product_toolbox)** for *Trin for trin*, værktøjer og skabeloner.
+
+
 Her samles og beskrives de faste arbejdsgange, som sikrer kvalitet, ensartethed og overblik i sekretariatets drift og projekter. Afsnittet supplerer OS2’s governance-model og fungerer som både arbejdsgrundlag for sekretariatets daglige praksis og orientering for produktkoordinatorer, bestyrelse og samarbejdspartnere.
 
 


### PR DESCRIPTION
Relates to #22 

**Hvad**
- Tilføjer kort ramme-intro + labels på “Processer og rutiner”.
- Linker tydeligt til Værktøjskassen for Trin for trin/How-to.

**Hvorfor**
- Gør siden til ren overbliksside (forstå), og sender handling til Værktøjskassen (gør).

**Bemærk**
- Ingen filflyt eller URL-ændringer.
- GitHub preview viser labels som tekst; på det byggede site bliver de til pills.

**Screenshot**
- Se “Files changed” → top af filen (H1 + labels + 2 intro-linjer).
<img width="757" height="947" alt="Screenshot 2025-12-03 at 12 20 31" src="https://github.com/user-attachments/assets/0dec76b9-66e6-4fe8-aab2-a93a13cd45b9" />

