### PR TITLE
42 urgent hotfix external links are failing

### DIFF
--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -41,7 +41,7 @@ De bruges som reference for governance, samarbejde og medlemskab.
 ## Ofte stillede spørgsmål (FAQ) {#faq}
 Spørgsmål som ofte besvares.  
 
-- Hvor finder jeg skabeloner og vejledninger? → I denne håndbog eller på [GitHub](https://github.com/OS2offdig) / [Nextcloud](boks.os2.eu/s/Di5cTQdSABd6ak4).  
+- Hvor finder jeg skabeloner og vejledninger? → I denne håndbog eller på [GitHub](https://github.com/OS2offdig) / [Nextcloud](https://boks.os2.eu/s/Di5cTQdSABd6ak4).  
 - Hvordan registrerer jeg tid i Leantime? → Se *[Struktur for tidsregistrering](processes/os2_tidsregistrering.md)*.  
 - Hvem godkender fakturaer? → Se *[Oversigt over fakturagodkendere](processes/os2_faktura_godkender.md)*.  
 - Hvor kan jeg læse om governance-modellen? → Se *[Governance side på os2.eu](https://governance.os2.eu)*.  

--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -43,7 +43,7 @@ Spørgsmål som ofte besvares.
 
 - Hvor finder jeg skabeloner og vejledninger? → I denne håndbog eller på [GitHub](https://github.com/OS2offdig) / [Nextcloud](https://boks.os2.eu/s/Di5cTQdSABd6ak4).  
 - Hvordan registrerer jeg tid i Leantime? → Se *[Struktur for tidsregistrering](processes/os2_tidsregistrering)*.  
-- Hvem godkender fakturaer? → Se *[Oversigt over fakturagodkendere](processes/os2_faktura_godkender.md)*.  
+- Hvem godkender fakturaer? → Se *[Oversigt over fakturagodkendere](processes/os2_faktura_godkender)*.  
 - Hvor kan jeg læse om governance-modellen? → Se *[Governance side på os2.eu](https://governance.os2.eu)*.  
 
 

--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -42,7 +42,7 @@ De bruges som reference for governance, samarbejde og medlemskab.
 Spørgsmål som ofte besvares.  
 
 - Hvor finder jeg skabeloner og vejledninger? → I denne håndbog eller på [GitHub](https://github.com/OS2offdig) / [Nextcloud](https://boks.os2.eu/s/Di5cTQdSABd6ak4).  
-- Hvordan registrerer jeg tid i Leantime? → Se *[Struktur for tidsregistrering](processes/os2_tidsregistrering.md)*.  
+- Hvordan registrerer jeg tid i Leantime? → Se *[Struktur for tidsregistrering](processes/os2_tidsregistrering)*.  
 - Hvem godkender fakturaer? → Se *[Oversigt over fakturagodkendere](processes/os2_faktura_godkender.md)*.  
 - Hvor kan jeg læse om governance-modellen? → Se *[Governance side på os2.eu](https://governance.os2.eu)*.  
 

--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -41,7 +41,7 @@ De bruges som reference for governance, samarbejde og medlemskab.
 ## Ofte stillede spørgsmål (FAQ) {#faq}
 Spørgsmål som ofte besvares.  
 
-- Hvor finder jeg skabeloner og vejledninger? → I denne håndbog eller på [GitHub](https://github.com/OS2offdig) / [Nextcloud](https://boks.os2.eu/s/Di5cTQdSABd6ak4).  
+- Hvor finder jeg skabeloner og vejledninger? → I denne håndbog eller på [GitHub](https://github.com/OS2offdig) / [Nextcloud](https://boks.os2.eu/s/Di5cTQdSABd6ak4?dir=/Skabeloner).  
 - Hvordan registrerer jeg tid i Leantime? → Se *[Struktur for tidsregistrering](processes/os2_tidsregistrering)*.  
 - Hvem godkender fakturaer? → Se *[Oversigt over fakturagodkendere](processes/os2_faktura_godkender)*.  
 - Hvor kan jeg læse om governance-modellen? → Se *[Governance side på os2.eu](https://governance.os2.eu)*.  

--- a/docs/products_and_communities.md
+++ b/docs/products_and_communities.md
@@ -142,7 +142,7 @@ Sekretariatet bistår med vurdering, dokumentation og kontakt til bestyrelsen.
 
 ## Skabeloner og vejledninger {#templates}
 OS2 anvender en række fælles skabeloner for at sikre kvalitet og ensartethed i produktarbejdet.  
-Alle skabeloner findes i GitHub og Nextcloud. Listen er ikke udtømmende, [bidrag](./docs/CONTRIBUTE.md) gerne med manglende skabeloner eller forbedringer.
+Alle skabeloner findes i GitHub og Nextcloud. Listen er ikke udtømmende, [bidrag](../CONTRIBUTING.md) gerne med manglende skabeloner eller forbedringer.
 
 | Dokument / skabelon | Formål | Placering |
 |----------------------|---------|-----------|


### PR DESCRIPTION
## Beskrivelse

Rettelser af broken links i dokumentationen:

- **appendix.md:44** - Tilføjet manglende `https://` prefix til Nextcloud link
- **products_and_communities.md:145** - Rettet forkert sti til CONTRIBUTING.md (var ./docs/CONTRIBUTE.md, nu ../CONTRIBUTING.md)
- **appendix.md:45** - Fjernet .md extension fra link til tidsregistrering
- **appendix.md:46** - Fjernet .md extension fra link til fakturagodkendere

## Hvad skal testes før merge

1. **Appendix FAQ-sektion**
   - Linje 44: "Nextcloud" link → burde pege på https://boks.os2.eu/s/Di5cTQdSABd6ak4?dir=/Skabeloner
   - Linje 45: "Struktur for tidsregistrering" → burde linke til /docs/processes/os2_tidsregistrering
   - Linje 46: "Oversigt over fakturagodkendere" → burde linke til /docs/processes/os2_faktura_godkender

2. **Products and communities**
   - Klik på "bidrag" → burde linke til /CONTRIBUTING.md